### PR TITLE
Rename repo jupyter-desktop-server ➡️  jupyter-remote-desktop-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Jupyter Remote Desktop Proxy
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterhub/jupyter-remote-desktop-proxy/main?urlpath=desktop)
 
-Run XFCE (or other desktop environments) on a JupyterHub.
+Run XFCE (or other desktop environments) on Jupyter.
 
 This is based on https://github.com/ryanlovett/nbnovnc.
+
+When this extension is launched it will run a Linux desktop on the Jupyter single-user server, and proxy it to your browser using VNC via Jupyter.
 
 If a `vncserver` executable is found in `PATH` it will be used, otherwise a bundled TightVNC server is run.
 You can use this to install vncserver with support for other features, for example the [`Dockerfile`](./Dockerfile) in this repository installs TurboVNC for improved OpenGL support.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Jupyter Remote Desktop Proxy
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterhub/jupyter-remote-desktop-proxy/master?urlpath=desktop)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterhub/jupyter-remote-desktop-proxy/main?urlpath=desktop)
 
 Run XFCE (or other desktop environments) on a JupyterHub.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Jupyter Desktop Server
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/yuvipanda/jupyter-desktop-server/master?urlpath=desktop)
+# Jupyter Remote Desktop Proxy
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterhub/jupyter-remote-desktop-proxy/master?urlpath=desktop)
 
 Run XFCE (or other desktop environments) on a JupyterHub.
 
-This is based on https://github.com/ryanlovett/nbnovnc and a fork of https://github.com/manics/jupyter-omeroanalysis-desktop
+This is based on https://github.com/ryanlovett/nbnovnc.
 
 If a `vncserver` executable is found in `PATH` it will be used, otherwise a bundled TightVNC server is run.
 You can use this to install vncserver with support for other features, for example the [`Dockerfile`](./Dockerfile) in this repository installs TurboVNC for improved OpenGL support.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Jupyter Remote Desktop Proxy
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterhub/jupyter-remote-desktop-proxy/main?urlpath=desktop)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterhub/jupyter-remote-desktop-proxy/HEAD?urlpath=desktop)
 
 Run XFCE (or other desktop environments) on Jupyter.
 


### PR DESCRIPTION
Closes https://github.com/jupyterhub/team-compass/issues/372

This renames the repository with the proposal in https://github.com/jupyterhub/team-compass/issues/372#issuecomment-773306829. It doesn't rename the Python package.

Also changed the master to main in the README, though the repo branch still needs to be renamed- after transferring the repo I can no longer administer the repo.