### PR TITLE
Quieten binder-badge bot

### DIFF
--- a/.github/workflows/binder-badge.yaml
+++ b/.github/workflows/binder-badge.yaml
@@ -10,6 +10,6 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: manics/action-binderbadge@main
+      - uses: manics/action-binderbadge@2.0.0
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/binder-badge.yaml
+++ b/.github/workflows/binder-badge.yaml
@@ -1,27 +1,15 @@
 #./.github/workflows/binder-badge.yaml
 name: Binder Badge
-on: [pull_request_target]
+on:
+  pull_request_target:
 
 jobs:
-  binder:
+  badge:
     runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
 
     steps:
-      - name: comment on PR with Binder link
-        uses: actions/github-script@v6
+      - uses: manics/action-binderbadge@main
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            var PR_HEAD_USERREPO = process.env.PR_HEAD_USERREPO;
-            var PR_HEAD_SHA = process.env.PR_HEAD_SHA;
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${PR_HEAD_USERREPO}/${PR_HEAD_SHA}?urlpath=desktop) :point_left: Launch a binder notebook on this branch for commit ${PR_HEAD_SHA}`
-            })
-        env:
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_HEAD_USERREPO: ${{ github.event.pull_request.head.repo.full_name }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use an action to comment once and update the comment instead of repeatedly commenting.

See https://github.com/jupyterhub/jupyter-remote-desktop-proxy/pull/2#issuecomment-775461687
This action should ensure there's only one comment that gets updated.