### PR TITLE
Add Hub/Lab/Notebook navigation buttons to VNC top bar

### DIFF
--- a/jupyter_desktop/share/web/noVNC-1.1.0/vnc_lite.html
+++ b/jupyter_desktop/share/web/noVNC-1.1.0/vnc_lite.html
@@ -43,13 +43,22 @@
         #status {
             text-align: center;
         }
-        #sendCtrlAltDelButton {
+        .vncButton {
             position: fixed;
             top: 0px;
-            right: 0px;
             border: 1px outset;
             padding: 5px 5px 4px 5px;
             cursor: pointer;
+        }
+        .vncButton a {
+            text-decoration: none;
+            color: white;
+        }
+        #jupyterHubHome {
+            left: 0px;
+        }
+        #sendCtrlAltDelButton {
+            right: 0px;
         }
 
         #screen {
@@ -195,8 +204,9 @@
 
 <body>
     <div id="top_bar">
+        <div id="jupyterHubHome" class="vncButton"><a href="../../../hub/home">Home</a></div>
         <div id="status">Loading</div>
-        <div id="sendCtrlAltDelButton">Send CtrlAltDel</div>
+        <div id="sendCtrlAltDelButton" class="vncButton">Send CtrlAltDel</div>
     </div>
     <div id="screen">
         <!-- This is where the remote screen will appear -->


### PR DESCRIPTION
This PR adds navigation buttons to the VNC client top bar.
Without it there are no links to navigate elsewhere or stop the container.

![screenshot_2021-04-22_16-00-25_151009480](https://user-images.githubusercontent.com/122319/115727435-e0a6c080-a383-11eb-8c56-52baea1fd8d2.png)

The CSS is a bit forced since buttons are using `position: fixed` with pixel level alignment.

CC'ing @titansmc