### PR TITLE
binder-badge workflow needs permissions.issues:write

### DIFF
--- a/.github/workflows/binder-badge.yaml
+++ b/.github/workflows/binder-badge.yaml
@@ -5,6 +5,8 @@ on: [pull_request_target]
 jobs:
   binder:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
     - name: comment on PR with Binder link
       uses: actions/github-script@v1


### PR DESCRIPTION
Follow-up from https://github.com/jupyterhub/team-compass/issues/398#issuecomment-823820922

The workflow needs explicit permissions to write to an issue.