### PR TITLE
binder-badge workflow needs permissions.pull-requests:write

### DIFF
--- a/.github/workflows/binder-badge.yaml
+++ b/.github/workflows/binder-badge.yaml
@@ -6,7 +6,7 @@ jobs:
   binder:
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      pull-requests: write
     steps:
     - name: comment on PR with Binder link
       uses: actions/github-script@v1


### PR DESCRIPTION
https://github.com/jupyterhub/jupyter-remote-desktop-proxy/pull/8 didn't work:
https://github.com/jupyterhub/jupyter-remote-desktop-proxy/pull/6/checks?check_run_id=2418322936

Try `pull-requests: write` instead