### PR TITLE
Add logic to determine if vncserver is TigerVNC

### DIFF
--- a/jupyter_remote_desktop_proxy/__init__.py
+++ b/jupyter_remote_desktop_proxy/__init__.py
@@ -13,19 +13,23 @@ def setup_desktop():
     sockets_path = os.path.join(sockets_dir, 'vnc-socket')
     vncserver = which('vncserver')
 
-    if vncserver:
-        vnc_args = [
-            vncserver,
-        ]
-        socket_args = []
-    else:
+    if vncserver is None:
         # Use bundled tigervnc
-        vnc_args = [
-            os.path.join(HERE, 'share/tigervnc/bin/vncserver'),
-            '-rfbunixpath',
-            sockets_path,
-        ]
+        vncserver = (os.path.join(HERE, 'share/tigervnc/bin/vncserver'),)
+
+    # TigerVNC provides the option to connect a Unix socket. TurboVNC does not.
+    # TurboVNC and TigerVNC share the same origin and both use a Perl script
+    # as the executable vncserver. We can determine if vncserver is TigerVNC
+    # by searching TigerVNC string in the Perl script.
+    with open(vncserver) as vncserver_file:
+        is_tigervnc = "TigerVNC" in vncserver_file.read()
+
+    if is_tigervnc:
+        vnc_args = [vncserver, '-rfbunixpath', sockets_path]
         socket_args = ['--unix-target', sockets_path]
+    else:
+        vnc_args = [vncserver]
+        socket_args = []
 
     vnc_command = ' '.join(
         shlex.quote(p)


### PR DESCRIPTION
The extension currently looks first is the executable `vncserver` is available in `PATH`. If it is, this what the extension will use and otherwise the extension the tigervnc bundled with the package.

The arguments (i.e.: `vnc_args`) provided to `vncserver` executable are also determined based on wether the executable comes from the system or the package bundle. However, it is possible that the `vncserver` provided by the system is also TigerVNC and that it could benefits from the same arguments as when using the bundled `vncserver`.

This PR splits that logic in two. First, we determine if `vncserver` can be provided by the system, then we determine if `vncserver` is TigerVNC or something else. Determining if `vncserver` is TigerVNC is a simple matter of looking for a string inside the perl script that is `vncserver`.

