### PR TITLE
Remove "/usr/bin" prefix in front of dbus-launch in xstartup

### DIFF
--- a/jupyter_remote_desktop_proxy/share/xstartup
+++ b/jupyter_remote_desktop_proxy/share/xstartup
@@ -1,3 +1,3 @@
 #!/bin/sh
 cd "$HOME"
-exec /usr/bin/dbus-launch xfce4-session
+exec dbus-launch xfce4-session


### PR DESCRIPTION
This allows xstartup to work with environment where dbus-launch is in PATH while not installed in standard /usr/bin.