### PR TITLE
Remove hardcoded display number and port, avoids multi-user conflicts

### DIFF
--- a/jupyter_remote_desktop_proxy/__init__.py
+++ b/jupyter_remote_desktop_proxy/__init__.py
@@ -40,7 +40,6 @@ def setup_desktop():
                 '-SecurityTypes',
                 'None',
                 '-fg',
-                ':1',
             ]
         )
     )
@@ -52,11 +51,10 @@ def setup_desktop():
             os.path.join(HERE, 'share/web/noVNC-1.2.0'),
             '--heartbeat',
             '30',
-            '5901',
+            '{port}',
         ]
         + socket_args
         + ['--', '/bin/sh', '-c', f'cd {os.getcwd()} && {vnc_command}'],
-        'port': 5901,
         'timeout': 30,
         'mappath': {'/': '/vnc_lite.html'},
         'new_browser_window': True,


### PR DESCRIPTION
In a multi-user environment, the display number and the port cannot have to be selected based on what is available. For the display number, vncserver uses the next free display number when unspecified. As for the port number for websockify, we let jupyter-server-proxy logic finds one for us.

Fix #18 