### PR TITLE
Let user defines its own xstartup and geometry

### DIFF
--- a/jupyter_remote_desktop_proxy/__init__.py
+++ b/jupyter_remote_desktop_proxy/__init__.py
@@ -31,12 +31,13 @@ def setup_desktop():
         vnc_args = [vncserver]
         socket_args = []
 
+    if not os.path.exists(os.path.expand('~/.vnc/xstartup')):
+        vnc_args.extend(['-xstartup', os.path.join(HERE, 'share/xstartup')])
+
     vnc_command = shlex.join(
         vnc_args
         + [
             '-verbose',
-            '-xstartup',
-            os.path.join(HERE, 'share/xstartup'),
             '-geometry',
             '1680x1050',
             '-SecurityTypes',
@@ -44,6 +45,7 @@ def setup_desktop():
             '-fg',
         ]
     )
+
     return {
         'command': [
             'websockify',


### PR DESCRIPTION
User can override the default provided xstartup by providing their own in the standard location ~/.vnc/xstartup. We also remove the prescribed geometry to let the user define its own using vnc config or the session manager.