### PR TITLE
Allow user to define their own xstartup file

### DIFF
--- a/jupyter_remote_desktop_proxy/__init__.py
+++ b/jupyter_remote_desktop_proxy/__init__.py
@@ -38,6 +38,8 @@ def setup_desktop():
             vnc_args
             + [
                 '-verbose',
+                '-geometry',
+                '1680x1050',
                 '-SecurityTypes',
                 'None',
                 '-fg',

--- a/jupyter_remote_desktop_proxy/__init__.py
+++ b/jupyter_remote_desktop_proxy/__init__.py
@@ -27,16 +27,15 @@ def setup_desktop():
         ]
         socket_args = ['--unix-target', sockets_path]
 
+    if not os.path.exists(os.path.expand('~/.vnc/xstartup')):
+        vnc_args.extend(['-xstartup', os.path.join(HERE, 'share/xstartup')])
+
     vnc_command = ' '.join(
         shlex.quote(p)
         for p in (
             vnc_args
             + [
                 '-verbose',
-                '-xstartup',
-                os.path.join(HERE, 'share/xstartup'),
-                '-geometry',
-                '1680x1050',
                 '-SecurityTypes',
                 'None',
                 '-fg',

--- a/jupyter_remote_desktop_proxy/__init__.py
+++ b/jupyter_remote_desktop_proxy/__init__.py
@@ -28,6 +28,8 @@ def setup_desktop():
         socket_args = ['--unix-target', sockets_path]
 
     if not os.path.exists(os.path.expand('~/.vnc/xstartup')):
+        # If there's an existing xstartup file in the default place VNC
+        # servers look for, let's not add our own.
         vnc_args.extend(['-xstartup', os.path.join(HERE, 'share/xstartup')])
 
     vnc_command = ' '.join(


### PR DESCRIPTION
Builds on top of https://github.com/jupyterhub/jupyter-remote-desktop-proxy/pull/35,
with the following changes:

- Doesn't change anything about `-geometry` as that is still
  unclear, from https://github.com/jupyterhub/jupyter-remote-desktop-proxy/pull/35#issuecomment-1573212666
- Adds a comment about `xstartup` file