### PR TITLE
Use trusted publishing to push to PyPI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,6 +45,3 @@ jobs:
       - name: publish to pypi
         uses: pypa/gh-action-pypi-publish@release/v1
         if: startsWith(github.ref, 'refs/tags/')
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
I've added the appropriate knobs to PyPI to trust this workflow.