### PR TITLE
Sets static port for vnc (fixes #47)

### DIFF
--- a/jupyter_remote_desktop_proxy/__init__.py
+++ b/jupyter_remote_desktop_proxy/__init__.py
@@ -55,10 +55,11 @@ def setup_desktop():
             os.path.join(HERE, 'share/web/noVNC-1.2.0'),
             '--heartbeat',
             '30',
-            '{port}',
+            '5901',
         ]
         + socket_args
         + ['--', '/bin/sh', '-c', f'cd {os.getcwd()} && {vnc_command}'],
+        'port': 5901,
         'timeout': 30,
         'mappath': {'/': '/vnc_lite.html'},
         'new_browser_window': True,


### PR DESCRIPTION
Not using the static port breaks the image, rendering it unusable. This essentially reverts commit https://github.com/jupyterhub/jupyter-remote-desktop-proxy/commit/447bf86d66bced05e5a02160f2eb5c0739994b68 to fix this