### PR TITLE
Simplify developmental dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,35 +3,27 @@ FROM jupyter/base-notebook
 USER root
 
 RUN apt-get -y -q update \
- && apt-get -y -q upgrade \
  && apt-get -y -q install \
         dbus-x11 \
-        firefox \
         xfce4 \
         xfce4-panel \
         xfce4-session \
         xfce4-settings \
         xorg \
         xubuntu-icon-theme \
+        tigervnc-standalone-server \
+        tigervnc-xorg-extension \
     # chown $HOME to workaround that the xorg installation creates a
     # /home/jovyan/.cache directory owned by root
  && chown -R $NB_UID:$NB_GID $HOME \
  && rm -rf /var/lib/apt/lists/*
 
-# Install TurboVNC (https://github.com/TurboVNC/turbovnc)
-ARG TURBOVNC_VERSION=2.2.6
-RUN wget -q "https://sourceforge.net/projects/turbovnc/files/${TURBOVNC_VERSION}/turbovnc_${TURBOVNC_VERSION}_amd64.deb/download" -O turbovnc.deb \
- && apt-get install -y -q ./turbovnc.deb \
-    # remove light-locker to prevent screen lock
- && apt-get remove -y -q light-locker \
- && rm ./turbovnc.deb \
- && ln -s /opt/TurboVNC/bin/* /usr/local/bin/
-
-COPY jupyter_remote_desktop_proxy /opt/install/jupyter_remote_desktop_proxy
-COPY setup.py MANIFEST.in README.md LICENSE /opt/install/
-RUN fix-permissions /opt/install
-
 USER $NB_USER
+
+RUN mamba install --yes websockify
+
+COPY --chown=$NB_USER:$NB_USER jupyter_remote_desktop_proxy /opt/install/jupyter_remote_desktop_proxy
+COPY --chown=$NB_USER:$NB_USER setup.py MANIFEST.in README.md LICENSE /opt/install/
+
 RUN cd /opt/install \
- && mamba install -y websockify \
  && pip install -e .


### PR DESCRIPTION
- Don't run apt-get upgrade, is not necessary
- Use tigervnc from apt rather than what we turbovnc. This allows the image to work on ARM machines as well as getting us a newer version of everything. Also it's possible that TurboVNC doesn't work right now, see #54 
- Reorder and use COPY --chown to make rapid development faster with better caching
- Remove firefox install from apt, as that no longer works anyway (it' a snap). That's set up with https://github.com/jupyterhub/jupyter-remote-desktop-proxy/pull/51 correctly.