### PR TITLE
Revert "Simplify xtartup command"

### DIFF
--- a/jupyter_remote_desktop_proxy/share/xstartup
+++ b/jupyter_remote_desktop_proxy/share/xstartup
@@ -1,3 +1,3 @@
 #!/bin/sh
 cd "$HOME"
-exec startxfce4
+exec dbus-launch xfce4-session


### PR DESCRIPTION
Reverts jupyterhub/jupyter-remote-desktop-proxy#59

This actually prevents XFCE4 from starting.

![image](https://github.com/jupyterhub/jupyter-remote-desktop-proxy/assets/30430/368e65c7-b459-487e-a396-d893cddbf1b9)
