### PR TITLE
Fix container build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,34 @@
+# This is a GitHub workflow defining a set of jobs with a set of steps.
+# ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+#
+name: Build
+
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - "dependabot/**"
+      - "pre-commit-ci-update-config"
+    tags: ["**"]
+  workflow_dispatch:
+
+jobs:
+  container:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build image
+        run: |
+          docker build -t jupyter-remote-desktop-proxy .
+
+      - name: Smoke test image
+        run: |
+          docker run -d -p 8888:8888 -e JUPYTER_TOKEN=secret jupyter-remote-desktop-proxy
+          sleep 10
+          curl 'http://localhost:8888/desktop/?token=secret' | grep 'Modified from novnc_lite.html example in noVNC'
+
+      # TODO: Check VNC desktop works, e.g. by comparing Playwright screenshots
+      # https://playwright.dev/docs/test-snapshots

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,7 @@
 # This is a GitHub workflow defining a set of jobs with a set of steps.
 # ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
 #
-name: Build
+name: Test
 
 on:
   pull_request:

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,9 @@ RUN apt-get -y -qq update \
         tigervnc-xorg-extension \
     # chown $HOME to workaround that the xorg installation creates a
     # /home/jovyan/.cache directory owned by root
- && chown -R $NB_UID:$NB_GID $HOME \
+    # Create /opt/install to ensure it's writable by pip
+ && mkdir -p /opt/install \
+ && chown -R $NB_UID:$NB_GID $HOME /opt/install \
  && rm -rf /var/lib/apt/lists/*
 
 USER $NB_USER

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,9 @@ RUN apt-get -y -q update \
 
 USER $NB_USER
 
-RUN mamba install --yes websockify
+COPY --chown=$NB_UID:$NB_GID jupyter_remote_desktop_proxy /opt/install/jupyter_remote_desktop_proxy
+COPY --chown=$NB_UID:$NB_GID environment.yml setup.py MANIFEST.in README.md LICENSE /opt/install/
 
-COPY --chown=$NB_USER:$NB_USER jupyter_remote_desktop_proxy /opt/install/jupyter_remote_desktop_proxy
-COPY --chown=$NB_USER:$NB_USER setup.py MANIFEST.in README.md LICENSE /opt/install/
-
-RUN cd /opt/install \
- && pip install -e .
+RUN cd /opt/install && \
+    . /opt/conda/bin/activate && \
+    mamba env update --quiet --file environment.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM jupyter/base-notebook
+FROM quay.io/jupyter/base-notebook:latest
 
 USER root
 
-RUN apt-get -y -q update \
- && apt-get -y -q install \
+RUN apt-get -y -qq update \
+ && apt-get -y -qq install \
         dbus-x11 \
         xfce4 \
         xfce4-panel \

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Jupyter Remote Desktop Proxy
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterhub/jupyter-remote-desktop-proxy/HEAD?urlpath=desktop)
-[![Build](https://github.com/jupyterhub/jupyter-remote-desktop-proxy/actions/workflows/build.yaml/badge.svg)](https://github.com/jupyterhub/jupyter-remote-desktop-proxy/actions/workflows/build.yaml)
+[![Test](https://github.com/jupyterhub/jupyter-remote-desktop-proxy/actions/workflows/test.yaml/badge.svg)](https://github.com/jupyterhub/jupyter-remote-desktop-proxy/actions/workflows/test.yaml)
 [![Latest PyPI version](https://img.shields.io/pypi/v/jupyter-remote-desktop-proxy?logo=pypi)](https://pypi.python.org/pypi/jupyter-remote-desktop-proxy)
 [![Issue tracking - GitHub](https://img.shields.io/badge/issue_tracking-github-blue?logo=github)](https://github.com/jupyterhub/jupyter-remote-desktop-proxy/issues)
 [![Help forum - Discourse](https://img.shields.io/badge/help_forum-discourse-blue?logo=discourse)](https://discourse.jupyter.org/c/jupyterhub)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Jupyter Remote Desktop Proxy
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterhub/jupyter-remote-desktop-proxy/HEAD?urlpath=desktop)
+[![Build](https://github.com/jupyterhub/jupyter-remote-desktop-proxy/actions/workflows/build.yaml/badge.svg)](https://github.com/jupyterhub/jupyter-remote-desktop-proxy/actions/workflows/build.yaml)
 [![Latest PyPI version](https://img.shields.io/pypi/v/jupyter-remote-desktop-proxy?logo=pypi)](https://pypi.python.org/pypi/jupyter-remote-desktop-proxy)
 [![Issue tracking - GitHub](https://img.shields.io/badge/issue_tracking-github-blue?logo=github)](https://github.com/jupyterhub/jupyter-remote-desktop-proxy/issues)
 [![Help forum - Discourse](https://img.shields.io/badge/help_forum-discourse-blue?logo=discourse)](https://discourse.jupyter.org/c/jupyterhub)


### PR DESCRIPTION
The Dockerfile currently fails to build as there's no `jovyan` group (`$NB_GID` corresponds to the `users` group).

Also switches to quay.io for the base image, and uses environment.yml to install as many dependencies as possible from conda-forge. We need it for websockify so might as well use it for everything.