### PR TITLE
Add a "Hub Control Panel" menu item if running inside a JupyterHub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,5 @@ RUN . /opt/conda/bin/activate && \
 
 COPY --chown=$NB_UID:$NB_GID . /opt/install
 RUN . /opt/conda/bin/activate && \
-    pip install -e /opt/install
+    pip install -e /opt/install && \
+    jupyter server extension enable jupyter_remote_desktop_proxy

--- a/js/index.js
+++ b/js/index.js
@@ -30,8 +30,10 @@ function status(text) {
   document.getElementById("status").textContent = text;
 }
 
-// The websockify URL to connect to is the same URL we are rendering this page on!
-let websockifyUrl = new URL(window.location);
+// This page is served under the /desktop/, and the websockify websocket is served
+// under /desktop-websockify/ with the same base url as /desktop/. We resolve it relatively
+// this way.
+let websockifyUrl = new URL("../desktop-websockify/", window.location);
 websockifyUrl.protocol = window.location.protocol === "https:" ? "wss" : "ws";
 
 // Creating a new RFB object will start a new connection

--- a/js/index.js
+++ b/js/index.js
@@ -30,8 +30,8 @@ function status(text) {
   document.getElementById("status").textContent = text;
 }
 
-// Construct the websockify websocket URL we want to connect to
-let websockifyUrl = new URL("websockify", window.location);
+// The websockify URL to connect to is the same URL we are rendering this page on!
+let websockifyUrl = new URL(window.location);
 websockifyUrl.protocol = window.location.protocol === "https:" ? "wss" : "ws";
 
 // Creating a new RFB object will start a new connection

--- a/jupyter-config/jupyter_notebook_config.d/jupyter_remote_desktop_proxy.json
+++ b/jupyter-config/jupyter_notebook_config.d/jupyter_remote_desktop_proxy.json
@@ -1,0 +1,7 @@
+{
+  "NotebookApp": {
+    "nbserver_extensions": {
+      "jupyter_remote_desktop_proxy": true
+    }
+  }
+}

--- a/jupyter-config/jupyter_server_config.d/jupyter_remote_desktop_proxy.json
+++ b/jupyter-config/jupyter_server_config.d/jupyter_remote_desktop_proxy.json
@@ -1,0 +1,7 @@
+{
+  "ServerApp": {
+    "jpserver_extensions": {
+      "jupyter_remote_desktop_proxy": true
+    }
+  }
+}

--- a/jupyter_remote_desktop_proxy/handlers.py
+++ b/jupyter_remote_desktop_proxy/handlers.py
@@ -1,10 +1,7 @@
 import os
-import shlex
-import tempfile
-from shutil import which
 
 import jinja2
-from jupyter_server_proxy.handlers import SuperviseAndProxyHandler
+from jupyter_server.base.handlers import JupyterHandler
 from tornado import web
 
 jinja_env = jinja2.Environment(
@@ -17,66 +14,9 @@ jinja_env = jinja2.Environment(
 HERE = os.path.dirname(os.path.abspath(__file__))
 
 
-def get_websockify_command():
-    # make a secure temporary directory for sockets
-    # This is only readable, writeable & searchable by our uid
-    sockets_dir = tempfile.mkdtemp()
-    sockets_path = os.path.join(sockets_dir, 'vnc-socket')
-    vncserver = which('vncserver')
-
-    if vncserver is None:
-        # Use bundled tigervnc
-        vncserver = os.path.join(HERE, 'share/tigervnc/bin/vncserver')
-
-    # TigerVNC provides the option to connect a Unix socket. TurboVNC does not.
-    # TurboVNC and TigerVNC share the same origin and both use a Perl script
-    # as the executable vncserver. We can determine if vncserver is TigerVNC
-    # by searching TigerVNC string in the Perl script.
-    with open(vncserver) as vncserver_file:
-        is_tigervnc = "TigerVNC" in vncserver_file.read()
-
-    if is_tigervnc:
-        vnc_args = [vncserver, '-rfbunixpath', sockets_path]
-        socket_args = ['--unix-target', sockets_path]
-    else:
-        vnc_args = [vncserver]
-        socket_args = []
-
-    if not os.path.exists(os.path.expanduser('~/.vnc/xstartup')):
-        vnc_args.extend(['-xstartup', os.path.join(HERE, 'share/xstartup')])
-
-    vnc_command = shlex.join(
-        vnc_args
-        + [
-            '-verbose',
-            '-geometry',
-            '1680x1050',
-            '-SecurityTypes',
-            'None',
-            '-fg',
-        ]
-    )
-
-    return (
-        [
-            'websockify',
-            '-v',
-            '--heartbeat',
-            '30',
-            '{port}',
-        ]
-        + socket_args
-        + ['--', '/bin/sh', '-c', f'cd {os.getcwd()} && {vnc_command}']
-    )
-
-
-class DesktopHandler(SuperviseAndProxyHandler):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.command = get_websockify_command()
-
+class DesktopHandler(JupyterHandler):
     @web.authenticated
-    async def http_get(self, *args, **kwargs):
+    async def get(self):
         template_params = {
             'base_url': self.base_url,
         }

--- a/jupyter_remote_desktop_proxy/handlers.py
+++ b/jupyter_remote_desktop_proxy/handlers.py
@@ -1,0 +1,84 @@
+import os
+import shlex
+import tempfile
+from shutil import which
+
+import jinja2
+from jupyter_server_proxy.handlers import SuperviseAndProxyHandler
+from tornado import web
+
+jinja_env = jinja2.Environment(
+    loader=jinja2.FileSystemLoader(
+        os.path.join(os.path.dirname(__file__), 'templates')
+    ),
+)
+
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def get_websockify_command():
+    # make a secure temporary directory for sockets
+    # This is only readable, writeable & searchable by our uid
+    sockets_dir = tempfile.mkdtemp()
+    sockets_path = os.path.join(sockets_dir, 'vnc-socket')
+    vncserver = which('vncserver')
+
+    if vncserver is None:
+        # Use bundled tigervnc
+        vncserver = os.path.join(HERE, 'share/tigervnc/bin/vncserver')
+
+    # TigerVNC provides the option to connect a Unix socket. TurboVNC does not.
+    # TurboVNC and TigerVNC share the same origin and both use a Perl script
+    # as the executable vncserver. We can determine if vncserver is TigerVNC
+    # by searching TigerVNC string in the Perl script.
+    with open(vncserver) as vncserver_file:
+        is_tigervnc = "TigerVNC" in vncserver_file.read()
+
+    if is_tigervnc:
+        vnc_args = [vncserver, '-rfbunixpath', sockets_path]
+        socket_args = ['--unix-target', sockets_path]
+    else:
+        vnc_args = [vncserver]
+        socket_args = []
+
+    if not os.path.exists(os.path.expanduser('~/.vnc/xstartup')):
+        vnc_args.extend(['-xstartup', os.path.join(HERE, 'share/xstartup')])
+
+    vnc_command = shlex.join(
+        vnc_args
+        + [
+            '-verbose',
+            '-geometry',
+            '1680x1050',
+            '-SecurityTypes',
+            'None',
+            '-fg',
+        ]
+    )
+
+    return (
+        [
+            'websockify',
+            '-v',
+            '--heartbeat',
+            '30',
+            '{port}',
+        ]
+        + socket_args
+        + ['--', '/bin/sh', '-c', f'cd {os.getcwd()} && {vnc_command}']
+    )
+
+
+class DesktopHandler(SuperviseAndProxyHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.command = get_websockify_command()
+
+    @web.authenticated
+    async def http_get(self, *args, **kwargs):
+        template_params = {
+            'base_url': self.base_url,
+        }
+        template_params.update(self.serverapp.jinja_template_vars)
+        self.write(jinja_env.get_template("index.html").render(**template_params))

--- a/jupyter_remote_desktop_proxy/server_extension.py
+++ b/jupyter_remote_desktop_proxy/server_extension.py
@@ -18,12 +18,15 @@ def load_jupyter_server_extension(server_app):
     server_app.web_app.add_handlers(
         ".*",
         [
+            # Serve our own static files
             (
                 url_path_join(base_url, "/desktop/static/(.*)"),
                 AuthenticatedFileHandler,
                 {"path": (str(HERE / "static"))},
             ),
+            # To simplify URL mapping, we make sure that /desktop/ always
+            # has a trailing slash
             (url_path_join(base_url, "/desktop"), AddSlashHandler),
-            (url_path_join(base_url, "/desktop/()"), DesktopHandler, {'state': {}}),
+            (url_path_join(base_url, "/desktop/"), DesktopHandler),
         ],
     )

--- a/jupyter_remote_desktop_proxy/server_extension.py
+++ b/jupyter_remote_desktop_proxy/server_extension.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+from jupyter_server.base.handlers import AuthenticatedFileHandler
+from jupyter_server.utils import url_path_join
+from jupyter_server_proxy.handlers import AddSlashHandler
+
+from .handlers import DesktopHandler
+
+HERE = Path(__file__).parent
+
+
+def load_jupyter_server_extension(server_app):
+    """
+    Called during notebook start
+    """
+    base_url = server_app.web_app.settings["base_url"]
+
+    server_app.web_app.add_handlers(
+        ".*",
+        [
+            (
+                url_path_join(base_url, "/desktop/static/(.*)"),
+                AuthenticatedFileHandler,
+                {"path": (str(HERE / "static"))},
+            ),
+            (url_path_join(base_url, "/desktop"), AddSlashHandler),
+            (url_path_join(base_url, "/desktop/()"), DesktopHandler, {'state': {}}),
+        ],
+    )

--- a/jupyter_remote_desktop_proxy/setup_websockify.py
+++ b/jupyter_remote_desktop_proxy/setup_websockify.py
@@ -1,0 +1,65 @@
+import os
+import shlex
+import tempfile
+from shutil import which
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def setup_websockify():
+    # make a secure temporary directory for sockets
+    # This is only readable, writeable & searchable by our uid
+    sockets_dir = tempfile.mkdtemp()
+    sockets_path = os.path.join(sockets_dir, 'vnc-socket')
+    vncserver = which('vncserver')
+
+    if vncserver is None:
+        # Use bundled tigervnc
+        vncserver = os.path.join(HERE, 'share/tigervnc/bin/vncserver')
+
+    # TigerVNC provides the option to connect a Unix socket. TurboVNC does not.
+    # TurboVNC and TigerVNC share the same origin and both use a Perl script
+    # as the executable vncserver. We can determine if vncserver is TigerVNC
+    # by searching TigerVNC string in the Perl script.
+    with open(vncserver) as vncserver_file:
+        is_tigervnc = "TigerVNC" in vncserver_file.read()
+
+    if is_tigervnc:
+        vnc_args = [vncserver, '-rfbunixpath', sockets_path]
+        socket_args = ['--unix-target', sockets_path]
+    else:
+        vnc_args = [vncserver]
+        socket_args = []
+
+    if not os.path.exists(os.path.expanduser('~/.vnc/xstartup')):
+        vnc_args.extend(['-xstartup', os.path.join(HERE, 'share/xstartup')])
+
+    vnc_command = shlex.join(
+        vnc_args
+        + [
+            '-verbose',
+            '-geometry',
+            '1680x1050',
+            '-SecurityTypes',
+            'None',
+            '-fg',
+        ]
+    )
+
+    return {
+        'command': [
+            'websockify',
+            '-v',
+            '--heartbeat',
+            '30',
+            '{port}',
+        ]
+        + socket_args
+        + ['--', '/bin/sh', '-c', f'cd {os.getcwd()} && {vnc_command}'],
+        'timeout': 30,
+        'new_browser_window': True,
+        # We want the launcher entry to point to /desktop/, not to /desktop-websockify/
+        # /desktop/ is the user facing URL, while /desktop-websockify/ now *only* serves
+        # websockets.
+        "launcher_entry": {"title": "Desktop", "path_info": "desktop"},
+    }

--- a/jupyter_remote_desktop_proxy/templates/index.html
+++ b/jupyter_remote_desktop_proxy/templates/index.html
@@ -13,13 +13,13 @@
                 Chrome Frame. -->
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
-    <link href="./dist/index.css" rel="stylesheet" />
+    <link href="{{ base_url }}desktop/static/dist/index.css" rel="stylesheet" />
   </head>
 
   <body>
     <div id="top-bar">
       <a href=".." id="logo">
-        <img src="./jupyter-logo.svg" />
+        <img src="{{base_url}}desktop/static/jupyter-logo.svg" />
       </a>
       <ul id="menu">
         <li id="status-container">
@@ -29,6 +29,11 @@
         <li>
           <a id="clipboard-button" href="#">Remote Clipboard</a>
         </li>
+        {% if hub_control_panel_url %}
+        <li>
+          <a href="{{ hub_control_panel_url }}">Hub Control Panel</a>
+        </li>
+        {% endif %}
       </ul>
     </div>
     <div id="screen">
@@ -47,6 +52,6 @@
       </div>
     </div>
 
-    <script src="./dist/viewer.js"></script>
+    <script src="{{base_url}}desktop/static/dist/viewer.js"></script>
   </body>
 </html>

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
             'desktop-websockify = jupyter_remote_desktop_proxy.setup_websockify:setup_websockify',
         ]
     },
-    stall_requires=[
+    install_requires=[
         'jupyter-server-proxy>=1.4.0',
     ],
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -58,11 +58,6 @@ setup(
         "Programming Language :: Python :: 3",
     ],
     description="Run a desktop environments on Jupyter",
-    entry_points={
-        'jupyter_serverproxy_servers': [
-            'desktop = jupyter_remote_desktop_proxy:setup_desktop',
-        ]
-    },
     install_requires=[
         'jupyter-server-proxy>=1.4.0',
     ],
@@ -85,4 +80,18 @@ setup(
         # Handles `pip install` directly
         "build_py": webpacked_command(build_py),
     },
+    data_files=[
+        (
+            'etc/jupyter/jupyter_server_config.d',
+            [
+                'jupyter-config/jupyter_server_config.d/jupyter_remote_desktop_proxy.json'
+            ],
+        ),
+        (
+            'etc/jupyter/jupyter_notebook_config.d',
+            [
+                'jupyter-config/jupyter_notebook_config.d/jupyter_remote_desktop_proxy.json'
+            ],
+        ),
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,12 @@ setup(
         "Programming Language :: Python :: 3",
     ],
     description="Run a desktop environments on Jupyter",
-    install_requires=[
+    entry_points={
+        'jupyter_serverproxy_servers': [
+            'desktop-websockify = jupyter_remote_desktop_proxy.setup_websockify:setup_websockify',
+        ]
+    },
+    stall_requires=[
         'jupyter-server-proxy>=1.4.0',
     ],
     include_package_data=True,


### PR DESCRIPTION
Based on https://github.com/jupyterhub/jupyter-remote-desktop-proxy/pull/78

I wanted to provide a "Hub Control Panel" menu item only when running in
a JupyterHub. To do this, we need to figure out *when* we are running in
a JupyterHub. There were two ways to do this:

1. Expose an API endpoint as a Jupyter Server extension, and then talk to this
   from a purely static JS code to figure out if we were on the hub, and if so,
   where the hub control panel is
2. Render the *html* as a jinja2 template from a Jupyter Server extension, leaving
    websockify for jupyter-server-proxy to handle

After some poking around (and trying a 3rd approach that's more complex), (2) seems
the right path. 

<img width="411" alt="image" src="https://github.com/jupyterhub/jupyter-remote-desktop-proxy/assets/30430/3fd00f81-41e3-4bd4-a07c-dd07539e2866">

A "Hub Control Panel" button is now added if we are running inside a hub,
but *not* added if we are *not* running inside a hub. I've tried to stick to
how other projects does it to whatever extent I can.

I'm also very excited because this gives us other extension opportunities
in the future :)

Fixes https://github.com/jupyterhub/jupyter-remote-desktop-proxy/issues/57