### PR TITLE
[Docker image] Install fonts-dejavu for use by terminals

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get -y -qq update \
         xfce4-settings \
         xorg \
         xubuntu-icon-theme \
+        fonts-dejavu \
         tigervnc-standalone-server \
         tigervnc-xorg-extension \
     # Disable the automatic screenlock since the account password is unknown


### PR DESCRIPTION
This is the default terminal font, and when not
installed, everything just renders weird.

EDIT by Erik: Closes #85 as its an alternative way of solving the same thing