### PR TITLE
Require jupyter-server-proxy 4+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         ]
     },
     install_requires=[
-        'jupyter-server-proxy>=1.4.0',
+        'jupyter-server-proxy>=4.1.0',
     ],
     include_package_data=True,
     keywords=["Interactive", "Desktop", "Jupyter"],


### PR DESCRIPTION
We don't have tests to verify things work with old versions of jupyter-server-proxy, so it feels good to enforce something new now that we are about to release a new major version.