### PR TITLE
Publish TigerVNC and TurboVNC image to quay.io

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,3 +57,75 @@ jobs:
       - name: publish to pypi
         uses: pypa/gh-action-pypi-publish@release/v1
         if: startsWith(github.ref, 'refs/tags/')
+
+  publish-images:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - vncserver: tigervnc
+          - vncserver: turbovnc
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU (for docker buildx)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx (for multi-arch builds)
+        uses: docker/setup-buildx-action@v3
+
+      - name: Make decisions to push etc.
+        id: decisions
+        run: |
+          if [ "${{ startsWith(github.ref, 'refs/tags/') || (github.ref == 'refs/heads/main') }}" = "true" ]; then
+              echo "push=true" >> $GITHUB_OUTPUT
+          else
+              echo "push=false" >> $GITHUB_OUTPUT
+          fi
+
+          # We provide image tags with -tigervnc and -turbovnc suffixes to allow
+          # for an explicit choice, but also ship with a default choice of
+          # TigerVNC.
+          if [ "${{ matrix.vncserver == 'tigervnc' }}" == "true" ]; then
+              echo "suffix=<empty-string>,-${{ matrix.vncserver }}" >> $GITHUB_OUTPUT
+          else
+              echo "suffix=-${{ matrix.vncserver }}" >> $GITHUB_OUTPUT
+          fi
+
+      # For builds triggered by a git tag 1.2.3, we calculate image tags like:
+      # [{prefix}:1.2.3, {prefix}:1.2, {prefix}:1, {prefix}:latest]
+      #
+      # More details at
+      # https://github.com/jupyterhub/action-major-minor-tag-calculator.
+      #
+      - name: Get image tags
+        id: tags
+        uses: jupyterhub/action-major-minor-tag-calculator@v3
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          prefix: "quay.io/jupyterhub/jupyter-remote-desktop-proxy:"
+          suffix: ${{ steps.decisions.outputs.suffix }}
+          branchRegex: ^\w[\w-.]*$
+          defaultTag: quay.io/jupyterhub/jupyter-remote-desktop-proxy:noref
+
+      - name: Login to container registry
+        # Credentials to Quay.io was setup by...
+        # 1. Creating a [Robot Account](https://quay.io/organization/jupyterhub?tab=robots)
+        # 2. Giving it push permissions to the image repository
+        # 3. Adding Robot Account credentials as workflow environment secrets
+        if: steps.decisions.outputs.push == 'true'
+        run: |
+          docker login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          build-args: |
+            vncserver=${{ matrix.vncserver }}
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ steps.decisions.outputs.push }}
+          tags: ${{ join(fromJson(steps.tags.outputs.tags)) }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Set up Docker Buildx (for multi-arch builds)
         uses: docker/setup-buildx-action@v3
 
-      - name: Make decisions to push etc.
+      - name: Make decisions on pushing and suffix (based on vnc server chosen)
         id: decisions
         run: |
           if [ "${{ startsWith(github.ref, 'refs/tags/') || (github.ref == 'refs/heads/main') }}" = "true" ]; then

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,17 +16,29 @@ jobs:
   container:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - vncserver: tigervnc
+          - vncserver: turbovnc
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Build image
         run: |
-          docker build -t jupyter-remote-desktop-proxy .
+          docker build --build-arg vncserver=${{ matrix.vncserver }} -t jupyter-remote-desktop-proxy .
 
       - name: Smoke test image
         run: |
-          docker run -d -p 8888:8888 -e JUPYTER_TOKEN=secret jupyter-remote-desktop-proxy
+          container_id=$(docker run -d -p 8888:8888 -e JUPYTER_TOKEN=secret jupyter-remote-desktop-proxy)
+
+          # -help flag is only available for TigerVNC, where TurboVNC can't
+          # print info without returning an error code.
+          docker exec $container_id vncserver -help || true
+          docker exec $container_id vncserver -list
+
           sleep 10
           curl 'http://localhost:8888/desktop/?token=secret' | grep 'Jupyter Remote Desktop Proxy'
           # Test if the built JS file is present in the image

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,6 @@ RUN apt-get -y -qq update \
         xorg \
         xubuntu-icon-theme \
         fonts-dejavu \
-        tigervnc-standalone-server \
-        tigervnc-xorg-extension \
     # Disable the automatic screenlock since the account password is unknown
  && apt-get -y -qq remove xfce4-screensaver \
     # chown $HOME to workaround that the xorg installation creates a
@@ -22,6 +20,31 @@ RUN apt-get -y -qq update \
  && mkdir -p /opt/install \
  && chown -R $NB_UID:$NB_GID $HOME /opt/install \
  && rm -rf /var/lib/apt/lists/*
+
+# Install a VNC server, either TigerVNC (default) or TurboVNC
+ARG vncserver=tigervnc
+RUN if [ "${vncserver}" = "tigervnc" ]; then \
+        echo "Installing TigerVNC"; \
+        apt-get -y -qq update; \
+        apt-get -y -qq install \
+            tigervnc-standalone-server \
+            tigervnc-xorg-extension \
+        ; \
+        rm -rf /var/lib/apt/lists/*; \
+    fi
+ENV PATH=/opt/TurboVNC/bin:$PATH
+RUN if [ "${vncserver}" = "turbovnc" ]; then \
+        echo "Installing TurboVNC"; \
+        # Install instructions from https://turbovnc.org/Downloads/YUM
+        wget -q -O- https://packagecloud.io/dcommander/turbovnc/gpgkey | \
+        gpg --dearmor >/etc/apt/trusted.gpg.d/TurboVNC.gpg; \
+        wget -O /etc/apt/sources.list.d/TurboVNC.list https://raw.githubusercontent.com/TurboVNC/repo/main/TurboVNC.list; \
+        apt-get -y -qq update; \
+        apt-get -y -qq install \
+            turbovnc \
+        ; \
+        rm -rf /var/lib/apt/lists/*; \
+    fi
 
 USER $NB_USER
 


### PR DESCRIPTION
This PR updates the Dockerfile so that it can build to include TigerVNC (default) or TurboVNC by passing `--build-arg vncserver=turbovnc`. It then automates a build and publishing of an image in two variants:

- `quay.io/jupyterhub/jupyter-remote-desktop-proxy:<version>` (the same as `-tigervnc`)
- `quay.io/jupyterhub/jupyter-remote-desktop-proxy:<version>-tigervnc`
- `quay.io/jupyterhub/jupyter-remote-desktop-proxy:<version>-turbovnc`

- Fixes #88
  Provides multi arch images, Amd64 and Arm64
- Fixes #68
  In a very primitive way though, where I think #93 improves on testing beyond this basic check