### PR TITLE
Fix automation to publish tigervnc and turbovnc images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,7 +90,7 @@ jobs:
           # for an explicit choice, but also ship with a default choice of
           # TigerVNC.
           if [ "${{ matrix.vncserver == 'tigervnc' }}" == "true" ]; then
-              echo "suffix=<empty-string>,-${{ matrix.vncserver }}" >> $GITHUB_OUTPUT
+              echo 'suffix="",-${{ matrix.vncserver }}' >> $GITHUB_OUTPUT
           else
               echo "suffix=-${{ matrix.vncserver }}" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
This is a followup to #94 where I used a syntax for a github action that changed since the PR was written initially (from `<empty-string>` to `""` to represent an empty string).