### PR TITLE
Fix TigerVNC detection for non-apt installations

### DIFF
--- a/jupyter_remote_desktop_proxy/setup_websockify.py
+++ b/jupyter_remote_desktop_proxy/setup_websockify.py
@@ -21,9 +21,17 @@ def setup_websockify():
     # TigerVNC provides the option to connect a Unix socket. TurboVNC does not.
     # TurboVNC and TigerVNC share the same origin and both use a Perl script
     # as the executable vncserver. We can determine if vncserver is TigerVNC
-    # by searching TigerVNC string in the Perl script.
+    # by searching tigervnc string in the Perl script.
+    #
+    # The content of the vncserver executable can differ depending on how
+    # TigerVNC and TurboVNC has been distributed. Below are files known to be
+    # read in some situations:
+    #
+    # - https://github.com/TigerVNC/tigervnc/blob/v1.13.1/unix/vncserver/vncserver.in
+    # - https://github.com/TurboVNC/turbovnc/blob/3.1.1/unix/vncserver.in
+    #
     with open(vncserver) as vncserver_file:
-        is_tigervnc = "TigerVNC" in vncserver_file.read()
+        is_tigervnc = "tigervnc" in vncserver_file.read().casefold()
 
     if is_tigervnc:
         vnc_args = [vncserver, '-rfbunixpath', sockets_path]


### PR DESCRIPTION
I think we checked the case sensitive TigerVNC string which works if TigerVNC was installed via `apt`, but may not work when installed in another way. On the other hand, at those times, checking for the case insensitive string would work then. So, this PR makes the check case insensitive.

- Fixes #69

Thank you @goekce for your thorough issue report!!