### PR TITLE
Fix failure to specify port for TurboVNC server

### DIFF
--- a/jupyter_remote_desktop_proxy/setup_websockify.py
+++ b/jupyter_remote_desktop_proxy/setup_websockify.py
@@ -37,7 +37,7 @@ def setup_websockify():
         vnc_args = [vncserver, '-rfbunixpath', sockets_path]
         socket_args = ['--unix-target', sockets_path]
     else:
-        vnc_args = [vncserver]
+        vnc_args = [vncserver, '-rfbport', '{port}']
         socket_args = []
 
     if not os.path.exists(os.path.expanduser('~/.vnc/xstartup')):


### PR DESCRIPTION
Without specifying a port for TurboVNC, we will fail to wrap it I think. jupyter-server-proxy will proxy to the port websockify listens to, and websockify is configure to listen to `{port}` correctly, but I think this port must be the same what is to be wrapped - otherwise it won't wrap that specific bind I think. Note that all examples include specifying websockify port for the wrapped command as well (or know it and match it without specifying it to match).

With this, things work - without it it doesn't for TurboVNC.

- Fixes #54

Debugged in https://github.com/jupyterhub/jupyter-remote-desktop-proxy/issues/98#issuecomment-1985044545. I've tested this to resolve #54 manually.