### PR TITLE
MANIFEST.in: Include templates/ directory

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 graft jupyter_remote_desktop_proxy/share
 graft jupyter_remote_desktop_proxy/static
+graft jupyter_remote_desktop_proxy/templates


### PR DESCRIPTION
The templates directory includes the index.html which is rendered by handlers.py. Without the index.html file it throws a 500 error.