### PR TITLE
Retry a few times when the initial connection fails

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -12,7 +12,7 @@ import RFB from "@novnc/novnc/core/rfb";
 import { setupTooltip } from "./tooltip.js";
 
 const maxRetryCount = 5;
-const retryInterval = 3;  // seconds
+const retryInterval = 3; // seconds
 
 // When this function is called we have successfully connected to a server
 function connectedToServer() {
@@ -57,23 +57,23 @@ function connect() {
     websockifyUrl.toString(),
     {},
   );
-  
+
   // Add listeners to important events from the RFB module
   rfb.addEventListener("connect", connectedToServer);
   rfb.addEventListener("disconnect", disconnectedFromServer);
-  
+
   // Scale our viewport so the user doesn't have to scroll
   rfb.scaleViewport = true;
-  
+
   // Use a CSS variable to set background color
   rfb.background = "var(--jupyter-medium-dark-grey)";
-  
+
   // Clipboard
   function clipboardReceive(e) {
     document.getElementById("clipboard-text").value = e.detail.text;
   }
   rfb.addEventListener("clipboard", clipboardReceive);
-  
+
   function clipboardSend() {
     const text = document.getElementById("clipboard-text").value;
     rfb.clipboardPasteFrom(text);
@@ -81,7 +81,7 @@ function connect() {
   document
     .getElementById("clipboard-text")
     .addEventListener("change", clipboardSend);
-  
+
   setupTooltip(
     document.getElementById("clipboard-button"),
     document.getElementById("clipboard-container"),

--- a/js/index.js
+++ b/js/index.js
@@ -11,6 +11,9 @@ import RFB from "@novnc/novnc/core/rfb";
 
 import { setupTooltip } from "./tooltip.js";
 
+const maxRetryCount = 5;
+const retryInterval = 3;  // seconds
+
 // When this function is called we have successfully connected to a server
 function connectedToServer() {
   status("Connected");
@@ -22,6 +25,15 @@ function disconnectedFromServer(e) {
     status("Disconnected");
   } else {
     status("Something went wrong, connection is closed");
+    if (retryCount < maxRetryCount) {
+      status(`Reconnecting in ${retryInterval} seconds`);
+      setTimeout(() => {
+        connect();
+        retryCount++;
+      }, retryInterval * 1000);
+    } else {
+      status("Failed to connect, giving up");
+    }
   }
 }
 
@@ -36,38 +48,45 @@ function status(text) {
 let websockifyUrl = new URL("../desktop-websockify/", window.location);
 websockifyUrl.protocol = window.location.protocol === "https:" ? "wss" : "ws";
 
-// Creating a new RFB object will start a new connection
-const rfb = new RFB(
-  document.getElementById("screen"),
-  websockifyUrl.toString(),
-  {},
-);
+let retryCount = 0;
 
-// Add listeners to important events from the RFB module
-rfb.addEventListener("connect", connectedToServer);
-rfb.addEventListener("disconnect", disconnectedFromServer);
-
-// Scale our viewport so the user doesn't have to scroll
-rfb.scaleViewport = true;
-
-// Use a CSS variable to set background color
-rfb.background = "var(--jupyter-medium-dark-grey)";
-
-// Clipboard
-function clipboardReceive(e) {
-  document.getElementById("clipboard-text").value = e.detail.text;
+function connect() {
+  // Creating a new RFB object will start a new connection
+  let rfb = new RFB(
+    document.getElementById("screen"),
+    websockifyUrl.toString(),
+    {},
+  );
+  
+  // Add listeners to important events from the RFB module
+  rfb.addEventListener("connect", connectedToServer);
+  rfb.addEventListener("disconnect", disconnectedFromServer);
+  
+  // Scale our viewport so the user doesn't have to scroll
+  rfb.scaleViewport = true;
+  
+  // Use a CSS variable to set background color
+  rfb.background = "var(--jupyter-medium-dark-grey)";
+  
+  // Clipboard
+  function clipboardReceive(e) {
+    document.getElementById("clipboard-text").value = e.detail.text;
+  }
+  rfb.addEventListener("clipboard", clipboardReceive);
+  
+  function clipboardSend() {
+    const text = document.getElementById("clipboard-text").value;
+    rfb.clipboardPasteFrom(text);
+  }
+  document
+    .getElementById("clipboard-text")
+    .addEventListener("change", clipboardSend);
+  
+  setupTooltip(
+    document.getElementById("clipboard-button"),
+    document.getElementById("clipboard-container"),
+  );
 }
-rfb.addEventListener("clipboard", clipboardReceive);
 
-function clipboardSend() {
-  const text = document.getElementById("clipboard-text").value;
-  rfb.clipboardPasteFrom(text);
-}
-document
-  .getElementById("clipboard-text")
-  .addEventListener("change", clipboardSend);
-
-setupTooltip(
-  document.getElementById("clipboard-button"),
-  document.getElementById("clipboard-container"),
-);
+// Start the connection
+connect();


### PR DESCRIPTION
Sometimes the initial websocket connection fails. This is a workaround that tries to connect a few times with some delay in between connection attempts when a request fails.

Relates to https://github.com/jupyterhub/jupyter-remote-desktop-proxy/issues/105. Although it doesn't solve the actual underlying issue, I think it's a reasonable fix from a UX point of view.

Here's a video of the patch in action:

https://github.com/jupyterhub/jupyter-remote-desktop-proxy/assets/1142203/81c5210e-5384-45e8-9549-c72a4b484775

