### PR TITLE
Update to use novnc 1.5.0

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -7,7 +7,7 @@ import "reset-css";
 import "./index.css";
 
 // RFB holds the API to connect and communicate with a VNC server
-import RFB from "@novnc/novnc/core/rfb";
+import RFB from "@novnc/novnc/lib/rfb";
 
 import { setupTooltip } from "./tooltip.js";
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@floating-ui/dom": "^1.6.1",
-    "@novnc/novnc": "~1.4.0",
+    "@novnc/novnc": "^1.5.0",
     "reset-css": "^5.0.2"
   },
   "scripts": {


### PR DESCRIPTION
1.4.0 has two copies of `rfb.js`
- `node_modules/@novnc/novnc/core/rfb.js`
- `node_modules/@novnc/novnc/lib/rfb.js`

1.5.0 only has one copy:
- `node_modules/@novnc/novnc/lib/rfb.js`
- https://github.com/novnc/noVNC/commit/b35cf6dd1253142267f68f052986d0560f7a495c

Closes https://github.com/jupyterhub/jupyter-remote-desktop-proxy/issues/117