### PR TITLE
Pin dockerfile SHA, bump monthly with dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -15,3 +15,10 @@ updates:
       interval: monthly
       time: "05:00"
       timezone: Etc/UTC
+
+  # Bump dockerfile FROM
+  - package-ecosystem: docker
+    directory: /
+    labels: [dependencies]
+    schedule:
+      interval: monthly

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/jupyter/base-notebook:latest
+FROM quay.io/jupyter/base-notebook@sha256:876e3c3e40c4f0a25d3a16223a158a2d582b1ad77ac94269d43a5f6256eb4eec
 
 USER root
 


### PR DESCRIPTION
This ensures we control the OS/Python/Jupyter/XFCE/VNC versions