### PR TITLE
Override xstartup with environment variable `JUPYTER_REMOTE_DESKTOP_PROXY_XSTARTUP`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ to start daemons (such as dbus, pulseaudio, etc) necessary for linux desktop
 to work. This is the option kubernetes runs with by default, so most kubernetes
 based JupyterHubs will not need any modifications for this to work.
 
+## Configuration
+
+The VNC server will default to launching `~/.vnc/xstartup`.
+If this file does not exist jupyter-remote-desktop-proxy will use a bundled `xstartup` file that launches `dbus-launch xfce4-session`.
+You can specify a custom script by setting the environment variable `JUPYTER_REMOTE_DESKTOP_PROXY_XSTARTUP`.
+
 ## Limitations
 
 1. Desktop applications that require access to OpenGL are currently unsupported.

--- a/jupyter_remote_desktop_proxy/setup_websockify.py
+++ b/jupyter_remote_desktop_proxy/setup_websockify.py
@@ -33,8 +33,11 @@ def setup_websockify():
         unix_socket = False
         vnc_args = [vncserver, '-localhost', '-rfbport', '{port}']
 
-    if not os.path.exists(os.path.expanduser('~/.vnc/xstartup')):
-        vnc_args.extend(['-xstartup', os.path.join(HERE, 'share/xstartup')])
+    xstartup = os.getenv("JUPYTER_REMOTE_DESKTOP_PROXY_XSTARTUP")
+    if not xstartup and not os.path.exists(os.path.expanduser('~/.vnc/xstartup')):
+        xstartup = os.path.join(HERE, 'share/xstartup')
+    if xstartup:
+        vnc_args.extend(['-xstartup', xstartup])
 
     vnc_command = shlex.join(
         vnc_args


### PR DESCRIPTION
Defines the variable `JUPYTER_REMOTE_DESKTOP_PROXY_XSTARTUP` to launch a custom xstartup script.

The main benefit of this is launching a different desktop e.g. https://github.com/manics/jupyter-desktop-mate/blob/main/start-mate.sh on a system where a user's home directory may be mounted, meaning `~/.vnc/xstartup` doesn't exist.

Ideally this would be done with a traitlets configuration so it could be specified in one of the standard configuration paths, but the VNC server and desktop are launched using a custom jupyter-server-proxy entrypoint
https://github.com/jupyterhub/jupyter-remote-desktop-proxy/blob/4f68d135bde2bc06dd59762d4c70565c031ac34d/setup.py#L62-L64
so as far as I know it's not possible to pass a traitlets configuration object to it.