### PR TITLE
Pin js dependency novnc to 1.5.0 until we support 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@floating-ui/dom": "^1.6.1",
-    "@novnc/novnc": "^1.5.0",
+    "@novnc/novnc": "1.5.0",
     "reset-css": "^5.0.2"
   },
   "scripts": {


### PR DESCRIPTION
novnc 1.6.0 was released 4 days ago, and with it it seems we have a JS build failure when running `npm run webpack`. Not functioning with 1.6.0 is tracked by #141.