### PR TITLE
Access TurboVNC via a unix socket instead of a port

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,7 +55,7 @@ jobs:
         run: |
           # -help flag is not available for TurboVNC, but it emits the -help
           # equivalent information anyhow if passed -help, but also errors. Due
-          # to this, we fallback to use the errorcode of vncsrever -list.
+          # to this, we fallback to use the errorcode of vncserver -list.
           docker run test bash -c "vncserver -help || vncserver -list > /dev/null"
 
       - name: Test vncserver

--- a/README.md
+++ b/README.md
@@ -16,14 +16,21 @@ When this extension is launched it will run a Linux desktop on the Jupyter singl
 
 ## VNC Server
 
-This extension requires a [VNC Server](https://en.wikipedia.org/wiki/Virtual_Network_Computing)
-to be installed on the system (likely, in the container image). The
-most tested VNC server is [TigerVNC](https://tigervnc.org/), while
-[TurboVNC](https://www.turbovnc.org/) also works. Any VNC server available
-in `$PATH` as `vncserver` will be used, but no real testing outside of
-these servers has been performed.
+This extension requires installing a [VNC server] on the system (likely in a
+container image). Compatibility with the latest version of [TigerVNC] and
+[TurboVNC] is maintained and verified with tests, but other VNC servers
+available in `$PATH` as `vncserver` could also work. The `vncserver` binary
+needs to accept the [flags seen passed here], such as `-rfbunixpath` and a few
+others.
 
-For an example, see the [`Dockerfile`](./Dockerfile) in this repository which installs TigerVNC and XFCE4.
+For an example, see the [`Dockerfile`](./Dockerfile) in this repository which
+installs either TigerVNC or TurboVNC together with XFCE4.
+
+[vnc server]: https://en.wikipedia.org/wiki/Virtual_Network_Computing
+[tigervnc]: https://tigervnc.org/
+[turbovnc]: https://www.turbovnc.org/
+[flags seen passed here]: https://github.com/jupyterhub/jupyter-remote-desktop-proxy/blob/main/jupyter_remote_desktop_proxy/setup_websockify.py
+[xfce4]: https://www.xfce.org/
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ installs either TigerVNC or TurboVNC together with XFCE4.
 
 2. Install the packages needed to provide a VNC server and the actual Linux Desktop environment.
    You need to pick a desktop environment (there are many!) - here are the packages
-   to use TigerVNC and the light-weight [XFCE4](https://www.xfce.org/) desktop environment on Ubuntu 22.04:
+   to use TigerVNC and the light-weight [XFCE4] desktop environment on Ubuntu 24.04:
 
    ```
    dbus-x11
@@ -53,7 +53,6 @@ installs either TigerVNC or TurboVNC together with XFCE4.
    xorg
    xubuntu-icon-theme
    tigervnc-standalone-server
-   tigervnc-xorg-extension
    ```
 
    The recommended way to install these is from your Linux system package manager

--- a/jupyter_remote_desktop_proxy/setup_websockify.py
+++ b/jupyter_remote_desktop_proxy/setup_websockify.py
@@ -12,26 +12,8 @@ def setup_websockify():
             "vncserver executable not found, please install a VNC server"
         )
 
-    # TurboVNC and TigerVNC share the same origin and both use a Perl script
-    # as the executable vncserver. We can determine if vncserver is TigerVNC
-    # by searching tigervnc string in the Perl script.
-    #
-    # The content of the vncserver executable can differ depending on how
-    # TigerVNC and TurboVNC has been distributed. Below are files known to be
-    # read in some situations:
-    #
-    # - https://github.com/TigerVNC/tigervnc/blob/v1.13.1/unix/vncserver/vncserver.in
-    # - https://github.com/TurboVNC/turbovnc/blob/3.1.1/unix/vncserver.in
-    #
-    with open(vncserver) as vncserver_file:
-        is_tigervnc = "tigervnc" in vncserver_file.read().casefold()
-
-    if is_tigervnc:
-        unix_socket = True
-        vnc_args = [vncserver, '-rfbunixpath', "{unix_socket}"]
-    else:
-        unix_socket = False
-        vnc_args = [vncserver, '-localhost', '-rfbport', '{port}']
+    # {unix_socket} is expanded by jupyter-server-proxy
+    vnc_args = [vncserver, '-rfbunixpath', '{unix_socket}']
 
     xstartup = os.getenv("JUPYTER_REMOTE_DESKTOP_PROXY_XSTARTUP")
     if not xstartup and not os.path.exists(os.path.expanduser('~/.vnc/xstartup')):
@@ -59,6 +41,6 @@ def setup_websockify():
         # /desktop/ is the user facing URL, while /desktop-websockify/ now *only* serves
         # websockets.
         "launcher_entry": {"title": "Desktop", "path_info": "desktop"},
-        "unix_socket": unix_socket,
+        "unix_socket": True,
         "raw_socket_proxy": True,
     }


### PR DESCRIPTION
By exposing the TurboVNC vncserver with a unix socket file, created by jupyter-server-proxy with read/write permissions only for the current unix user, TurboVNC becomes suitable for example in the-littlest-jupyterhub deployments. The key difference is that multiple users can run their own VNC servers now without exposing it to other users, as a unix socket file compared to a TCP port, comes with user specific permissions.

## Breaking change

This requires TurboVNC 3.1.0 and is due to this a breaking change worth highlighting in a major release.

From the [3.1 beta.1 changelog](https://github.com/TurboVNC/turbovnc/blob/38dbbf30fd179621d2ee8578ed924fe09c9ef203/ChangeLog.md?plain=1#L424C1-L432C28):

> 6. The TurboVNC Server can now listen on a Unix domain socket, rather than a
TCP port, for connections from VNC viewers.  This is useful in conjunction with
SSH tunneling, and it also allows the Unix domain socket permissions to act as
an authentication mechanism for a TurboVNC session.  Two new Xvnc arguments,
`-rfbunixpath` and `-rfbunixmode`, can be used to specify the Unix domain
socket path and, optionally, the permissions.  A new `vncserver` argument,
`-uds`, causes the script to automatically choose an appropriate Unix domain
socket path under the TurboVNC user directory.  See the `Xvnc` and `vncserver`
man pages for more details.

The options `-rfbunixmode` and `-uds` shouldn't be of relevance since we use a pre-created socket file by `jupyter-server-proxy`.