### PR TITLE
add support for multiple endpoints, configured via JUPYTER_REMOTE_DESKTOP_ENDPOINTS

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -45,7 +45,10 @@ function status(text) {
 // This page is served under the /desktop/, and the websockify websocket is served
 // under /desktop-websockify/ with the same base url as /desktop/. We resolve it relatively
 // this way.
-let websockifyUrl = new URL("../desktop-websockify/", window.location);
+let websockifyUrl = new URL(
+  window.location.pathname.replace(/\/+$/, "") + "-websockify/",
+  window.location,
+);
 websockifyUrl.protocol = window.location.protocol === "https:" ? "wss" : "ws";
 
 let retryCount = 0;

--- a/jupyter_remote_desktop_proxy/server_extension.py
+++ b/jupyter_remote_desktop_proxy/server_extension.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 from jupyter_server.base.handlers import AuthenticatedFileHandler
@@ -15,18 +16,21 @@ def load_jupyter_server_extension(server_app):
     """
     base_url = server_app.web_app.settings["base_url"]
 
-    server_app.web_app.add_handlers(
-        ".*",
-        [
-            # Serve our own static files
-            (
-                url_path_join(base_url, "/desktop/static/(.*)"),
-                AuthenticatedFileHandler,
-                {"path": (str(HERE / "static"))},
-            ),
-            # To simplify URL mapping, we make sure that /desktop/ always
-            # has a trailing slash
-            (url_path_join(base_url, "/desktop"), AddSlashHandler),
-            (url_path_join(base_url, "/desktop/"), DesktopHandler),
-        ],
-    )
+    jupyter_remote_desktop_endpoints = os.getenv('JUPYTER_REMOTE_DESKTOP_ENDPOINTS', '')
+    endpoints = ['desktop'] + jupyter_remote_desktop_endpoints.split(',')
+    for endpoint in endpoints:
+        server_app.web_app.add_handlers(
+            ".*",
+            [
+                # Serve our own static files
+                (
+                    url_path_join(base_url, f"/{endpoint}/static/(.*)"),
+                    AuthenticatedFileHandler,
+                    {"path": (str(HERE / "static"))},
+                ),
+                # To simplify URL mapping, we make sure that /desktop/ always
+                # has a trailing slash
+                (url_path_join(base_url, f"/{endpoint}"), AddSlashHandler),
+                (url_path_join(base_url, f"/{endpoint}/"), DesktopHandler),
+            ],
+        )


### PR DESCRIPTION
To address https://github.com/jupyterhub/jupyter-remote-desktop-proxy/issues/157, alternative PR to https://github.com/jupyterhub/jupyter-remote-desktop-proxy/pull/158, which does not change the URL of the endpoints. 